### PR TITLE
Refatora twint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY requirements.txt /app
 WORKDIR /app
 
 # Install dependencies
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 EXPOSE $PORT

--- a/src/app.py
+++ b/src/app.py
@@ -10,14 +10,13 @@ from datetime import datetime, timedelta
 
 class WriteApp:
     def __init__(self, path):
-        self._df = pd.read_csv(path + "tweets.csv", sep="\t")
+
+        self._df = pd.read_csv(path + "tweets.csv")
         self.tweets = None
 
-    @staticmethod
     def data(self):
         return self._df
 
-    @staticmethod
     def tokenized_text(self):
         return self.tweets_tokenized
 
@@ -113,27 +112,27 @@ if lingua == "en":
     d = datetime.today() - timedelta(hours=0, minutes=timelapse)
     horadia = d.strftime("%Y-%m-%d %H:%M:%S")
 
-    ScrapeHashtagTwint(hash, horadia)
-
     if hash:
+        ScrapeHashtagTwint(hash, horadia)
         text = WriteApp(hash)
-        columns_to_temove = [
+
+        columns_to_remove = [
             "id",
             "conversation_id",
             "created_at",
-            "time",
+            # "time",
             "timezone",
             "user_id",
             "username",
             "name",
             "place",
             "language",
-            "mentions",
+            # "mentions",
             "urls",
             "photos",
-            "replies_count",
-            "retweets_count",
-            "likes_count",
+            # "replies_count",
+            # "retweets_count",
+            # "likes_count",
             "date",
             "hashtags",
             "cashtags",
@@ -154,7 +153,7 @@ if lingua == "en":
             "trans_src",
             "trans_dest",
         ]
-        text = text.remove_columns(columns_to_temove)
+        text = text.remove_columns(columns_to_remove)
         text = text.select_tweets().remove_url().remove_punctuation()
         text = text.tokenize().remove_stopwords()
 
@@ -216,27 +215,26 @@ elif lingua == "pt":
     d = datetime.today() - timedelta(hours=0, minutes=timelapse)
     horadia = d.strftime("%Y-%m-%d %H:%M:%S")
 
-    ScrapeHashtagTwint(hash, horadia)
-
     if hash:
+        ScrapeHashtagTwint(hash, horadia)
         text = WriteApp(hash)
-        columns_to_temove = [
+        columns_to_remove = [
             "id",
             "conversation_id",
             "created_at",
-            "time",
+            # "time",
             "timezone",
             "user_id",
             "username",
             "name",
             "place",
             "language",
-            "mentions",
+            # "mentions",
             "urls",
             "photos",
-            "replies_count",
-            "retweets_count",
-            "likes_count",
+            # "replies_count",
+            # "retweets_count",
+            # "likes_count",
             "date",
             "hashtags",
             "cashtags",
@@ -257,7 +255,7 @@ elif lingua == "pt":
             "trans_src",
             "trans_dest",
         ]
-        text = text.remove_columns(columns_to_temove)
+        text = text.remove_columns(columns_to_remove)
         text = text.select_tweets().remove_url().remove_punctuation()
         text = text.tokenize().remove_stopwords()
 

--- a/src/scrape/ScrapeTwint.py
+++ b/src/scrape/ScrapeTwint.py
@@ -1,13 +1,14 @@
-import os
+import twint
 
 
 def ScrapeHashtagTwint(hashtag, datetime):
-    os.system(
-        "twint -s "
-        + hashtag
-        + ' --since "'
-        + datetime
-        + '"  -o '
-        + hashtag
-        + "tweets.csv --csv "
-    )
+
+    c = twint.Config()
+    c.Search = hashtag
+    c.Since = datetime
+    c.Pandas = True
+    c.Hide_output = True
+
+    twint.run.Search(c)
+    df = twint.storage.panda.Tweets_df
+    df.to_csv(f"{hashtag}tweets.csv")


### PR DESCRIPTION
Resolve #27 

Refatora o scrape para ser nativo do twint e não chamar usando o `os`. 

## Pontos positivos

- Deixar o código mais legível e mais adaptável, caso queremos mudar no futuro;
- Acelera o código, pois não tem texto no terminal.
- A função `ScreepHashtagTwint` foi movida para [dentro](https://github.com/Manguetown/tweetcraft/pull/31/files#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L116-L119) do `if hash`, o que faz com que apenas seja chamada quando necessária, na versão anterior ela era chamada regulamente o que podia causar o app a ficar devagar.
- Adicionei o comando de atualizar o `pip` no `Dockerfile`.
## Possíveis pontos negativos

- Foi necessário remover algumas colunas que não estão presentes nesse método para pegar os dados. Estas são: "time", "mentions", "replies_count", "retweets_count", "likes_count".


## Futuro

Talvez ao invés de remover as colunas utilizando o método `remove_columns` e adicionar um método `select_columns` para selecionar somente as colunas que precisamos. Isso diminuiria o número de colunas que são necessárias de definir no código e deixa o código com mais intenção.